### PR TITLE
Remove link to kubernetes-client/community

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the utility part of the [go client](https://github.com/kubernetes-client/go). It has been added to the main
 repo using git submodules.
-For more information refer to [clients-library-structure](https://github.com/kubernetes-client/community/blob/master/design-docs/clients-library-structure.md).
+For more information refer to [clients-library-structure](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-client-structure-proposal.md).
 
 # Development
 Any changes to utilites in this repo should be send as a PR to this repo. After


### PR DESCRIPTION
Point directly to the file that the kubernetes/community link was
pointing to

ref: https://github.com/kubernetes-client/community/issues/6